### PR TITLE
[sc21964] Remove upper base bound

### DIFF
--- a/monad-redis.cabal
+++ b/monad-redis.cabal
@@ -27,7 +27,7 @@ library
                       TypeFamilies,
                       UndecidableInstances
   -- other-extensions:    
-  build-depends:       base >=4.8 && <4.13,
+  build-depends:       base >=4.8,
                        bytestring,
                        exceptions >= 0.8,
                        hedis >= 0.9,


### PR DESCRIPTION
Upper base bounds can be useful with Cabal and its solver.

But base is unlikely to change the things we use here, so lets
optimistically claim we work with all future base versions.

This fixes GHC 9 compatibility.